### PR TITLE
Add error parsing method and expose TargetModuleName

### DIFF
--- a/post.js
+++ b/post.js
@@ -26,6 +26,21 @@ function resolveModuleName(moduleId){
   return moduleNames[moduleId];
 }
 
+function parseError(TModuleRec){
+  var errFilter = /(\d+)-(.+)/;
+  var errorDetails = errFilter.exec(TModuleRec.Error);
+  if(errorDetails){
+    var err = new Error(errorDetails[2]);
+    err.code = parseInt(errorDetails[1], 10);
+
+    err.errorPosition = TModuleRec.ErrorStart;
+    err.errorLength = TModuleRec.ErrorLength;
+    err.raw = TModuleRec.Error;
+    return err;
+  }
+  return TModuleRec.Error;
+}
+
 function parse(resultBuffer){
 
   var TModuleRec = {
@@ -75,19 +90,9 @@ function parse(resultBuffer){
     //3 padding bytes
   };
 
+  TModuleRec.Error = parseError(TModuleRec);
+
   return TModuleRec;
-}
-
-function parseError(TModuleRec){
-  var errFilter = /(\d+)-(.+)/;
-  var errorDetails = errFilter.exec(TModuleRec.Error);
-  var err = new Error(errorDetails[2]);
-  err.code = parseInt(errorDetails[1], 10);
-
-  err.result = TModuleRec;
-  err.errorPosition = TModuleRec.ErrorStart;
-  err.errorLength = TModuleRec.ErrorLength;
-  return err;
 }
 
 //program String, Source code
@@ -165,6 +170,5 @@ function testRecAlignment(){
 module.exports = {
   version: version,
   compile: compile,
-  parseError: parseError,
   testRecAlignment: testRecAlignment
 };

--- a/test/testsuite.js
+++ b/test/testsuite.js
@@ -154,7 +154,7 @@ function validateResult(test, result){
     expect(result.Succeeded).toBe(false);
     var expectedError = _.get(test, 'expect[0]');
     if(expectedError && expectedError.length > 0){
-      expect(result.Error).toInclude(expectedError);
+      expect(result.Error.raw).toInclude(expectedError);
     }
   }
   testResultNumber(test, result, 'LanguageVersion', 'language');

--- a/test/tokenizer.js
+++ b/test/tokenizer.js
@@ -50,7 +50,7 @@ describe('tokenizer', function(){
     done();
   });
 
-  it('#successfuly compiles without targetModule argument', function(done){
+  it('#successfully compiles without targetModule argument', function(done){
 
     var program = '\'{$STAMP BS2}\n' +
     'Counter VAR BYTE\n' +
@@ -93,7 +93,7 @@ describe('tokenizer', function(){
     done();
   });
 
-  it('#successfuly compiles with targetModule argument', function(done){
+  it('#successfully compiles with targetModule argument', function(done){
 
     var program = '\'{$STAMP BS2}\n' +
     'Counter VAR BYTE\n' +
@@ -156,6 +156,36 @@ describe('tokenizer', function(){
     expect(TModuleRec.TargetStart).toEqual(9);
     expect(TModuleRec.LanguageVersion).toEqual(200);
     expect(TModuleRec.LanguageStart).toEqual(0);
+    done();
+  });
+
+
+  it('#should parse an error state', function(done){
+
+    var program = '\'{$STAMP BS2}\n' +
+    ' VAR BYTE\n' + //should be  'Counter VAR BYTE\n' +
+    'FOR Counter = 1 to 20\n' +
+    '  PULSOUT 0,50000\n' +
+    '  PAUSE 250\n' +
+    'NEXT\n' +
+    'STOP';
+
+    var TModuleRec = bs2tokenize.compile(program, false);
+
+    expect(TModuleRec.Succeeded).toEqual(false);
+    expect(TModuleRec.Error).toEqual('149-Expected a label, variable, or instruction');
+    expect(TModuleRec.DebugFlag).toEqual(false);
+    expect(TModuleRec.TargetModule).toEqual(2);
+    expect(TModuleRec.TargetStart).toEqual(9);
+    expect(TModuleRec.LanguageVersion).toEqual(200);
+    expect(TModuleRec.LanguageStart).toEqual(0);
+
+    var parsedErr = bs2tokenize.parseError(TModuleRec);
+    expect(parsedErr.message).toEqual('Expected a label, variable, or instruction');
+    expect(parsedErr.code).toEqual(149);
+    expect(parsedErr.errorPosition).toEqual(15);
+    expect(parsedErr.errorLength).toEqual(3);
+
     done();
   });
 

--- a/test/tokenizer.js
+++ b/test/tokenizer.js
@@ -31,6 +31,7 @@ describe('tokenizer', function(){
     expect(TModuleRec.Error).toEqual('');
     expect(TModuleRec.DebugFlag).toEqual(true);
     expect(TModuleRec.TargetModule).toEqual(2);
+    expect(TModuleRec.TargetModuleName).toEqual('BS2');
     expect(TModuleRec.TargetStart).toEqual(3);
     expect(TModuleRec.ProjectFiles).toEqual(['4', '5', '6', '7', '8', '9', '10']);
     expect(TModuleRec.ProjectFilesStart).toEqual([11, 12, 13, 14, 15, 16, 17]);
@@ -81,6 +82,7 @@ describe('tokenizer', function(){
     expect(TModuleRec.Error).toEqual('');
     expect(TModuleRec.DebugFlag).toEqual(false);
     expect(TModuleRec.TargetModule).toEqual(2);
+    expect(TModuleRec.TargetModuleName).toEqual('BS2');
     expect(TModuleRec.TargetStart).toEqual(9);
     expect(TModuleRec.LanguageVersion).toEqual(200);
     expect(TModuleRec.LanguageStart).toEqual(0);
@@ -124,6 +126,7 @@ describe('tokenizer', function(){
     expect(TModuleRec.Error).toEqual('');
     expect(TModuleRec.DebugFlag).toEqual(false);
     expect(TModuleRec.TargetModule).toEqual(2);
+    expect(TModuleRec.TargetModuleName).toEqual('BS2');
     expect(TModuleRec.TargetStart).toEqual(0);
     expect(TModuleRec.LanguageVersion).toEqual(200);
     expect(TModuleRec.LanguageStart).toEqual(0);

--- a/test/tokenizer.js
+++ b/test/tokenizer.js
@@ -140,7 +140,7 @@ describe('tokenizer', function(){
   });
 
 
-  it('#returns an error string', function(done){
+  it('#returns an error object', function(done){
 
     var program = '\'{$STAMP BS2}\n' +
     ' VAR BYTE\n' + //should be  'Counter VAR BYTE\n' +
@@ -153,42 +153,16 @@ describe('tokenizer', function(){
     var TModuleRec = bs2tokenize.compile(program, false);
 
     expect(TModuleRec.Succeeded).toEqual(false);
-    expect(TModuleRec.Error).toEqual('149-Expected a label, variable, or instruction');
+    expect(TModuleRec.Error.raw).toEqual('149-Expected a label, variable, or instruction');
+    expect(TModuleRec.Error.message).toEqual('Expected a label, variable, or instruction');
+    expect(TModuleRec.Error.code).toEqual(149);
+    expect(TModuleRec.Error.errorPosition).toEqual(15);
+    expect(TModuleRec.Error.errorLength).toEqual(3);
     expect(TModuleRec.DebugFlag).toEqual(false);
     expect(TModuleRec.TargetModule).toEqual(2);
     expect(TModuleRec.TargetStart).toEqual(9);
     expect(TModuleRec.LanguageVersion).toEqual(200);
     expect(TModuleRec.LanguageStart).toEqual(0);
-    done();
-  });
-
-
-  it('#should parse an error state', function(done){
-
-    var program = '\'{$STAMP BS2}\n' +
-    ' VAR BYTE\n' + //should be  'Counter VAR BYTE\n' +
-    'FOR Counter = 1 to 20\n' +
-    '  PULSOUT 0,50000\n' +
-    '  PAUSE 250\n' +
-    'NEXT\n' +
-    'STOP';
-
-    var TModuleRec = bs2tokenize.compile(program, false);
-
-    expect(TModuleRec.Succeeded).toEqual(false);
-    expect(TModuleRec.Error).toEqual('149-Expected a label, variable, or instruction');
-    expect(TModuleRec.DebugFlag).toEqual(false);
-    expect(TModuleRec.TargetModule).toEqual(2);
-    expect(TModuleRec.TargetStart).toEqual(9);
-    expect(TModuleRec.LanguageVersion).toEqual(200);
-    expect(TModuleRec.LanguageStart).toEqual(0);
-
-    var parsedErr = bs2tokenize.parseError(TModuleRec);
-    expect(parsedErr.message).toEqual('Expected a label, variable, or instruction');
-    expect(parsedErr.code).toEqual(149);
-    expect(parsedErr.errorPosition).toEqual(15);
-    expect(parsedErr.errorLength).toEqual(3);
-
     done();
   });
 


### PR DESCRIPTION
#### What's this PR do?

Adds a `parseError` method that creates an error instance that describes the error state. Also exposes `TargetModuleName` that has the friendly name of the target board from the stamp directive.
#### How should this be manually tested?

Verify error position/length match expectations in the provided test case.
#### Any background context you want to provide?

`parseError` is used in `bs2-serial` to parse an error object on compile.
#### What are the relevant tickets?

parallaxinc/Parallax-IDE/issues/163
parallaxinc/Parallax-IDE/issues/132
